### PR TITLE
feat: reduce dockerfile build stages

### DIFF
--- a/Dockerfile copy
+++ b/Dockerfile copy
@@ -1,0 +1,34 @@
+# Get NPM packages
+FROM node:16-alpine AS dependencies
+RUN apk add --no-cache libc6-compat
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci
+
+# Rebuild the source code only when needed
+FROM node:16-alpine AS builder
+WORKDIR /app
+COPY . .
+COPY --from=dependencies /app/node_modules ./node_modules
+RUN npm run build
+
+# Production image, copy all the files and run next
+FROM node:16-alpine AS runner
+WORKDIR /app
+
+ENV NODE_ENV production
+
+RUN addgroup -g 1001 -S nodejs
+RUN adduser -S nextjs -u 1001
+
+COPY --from=builder --chown=nextjs:nodejs /app/.next ./.next
+COPY --from=builder /app/public ./public
+COPY --from=builder /app/package.json ./package.json
+COPY --from=builder /app/package-lock.json ./package-lock.json
+
+RUN npm ci --only=production
+
+USER nextjs
+EXPOSE 3000
+
+CMD ["npm", "start"]


### PR DESCRIPTION
This pull request seeks to improve the dockerfile to reduce the size of the cache generated by docker with each build.

It also reduces the number of layers to create the final application image.

By installing the dependencies before copying the files in the runner stage, we decrease the size of the cache generated by docker and decrease the build time.

